### PR TITLE
quickfix to icon path and documentation+build notes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,8 @@ RUN make backend-build
 ## build front
 FROM docker.io/library/node:15.14.0 as node
 
+# This step produces /src/frontend/dist which we will COPY into the final docker image
+
 WORKDIR /src
 COPY . .
 RUN make frontend-lint
@@ -28,7 +30,10 @@ RUN make frontend-build
 FROM docker.io/library/alpine
 RUN apk --no-cache add ca-certificates
 WORKDIR /app
+
+# Copy in the lander golang binary
 COPY --from=go   /src/lander .
+# Copy in the "dist" folder from the node stage
 COPY --from=node /src/frontend/dist /app/frontend/dist
 
 ## show us the sized just for the observability

--- a/README.md
+++ b/README.md
@@ -1,64 +1,33 @@
+# lander
 
+Simple kubernetes landing page..
 
-develop | master
----|---
-[![Build Status](https://ci.digtux.com/api/badges/digtux/lander/status.svg?ref=refs/heads/develop)](https://ci.digtux.com/digtux/lander) | [![Build Status](https://ci.digtux.com/api/badges/digtux/lander/status.svg?ref=refs/heads/master)](https://ci.digtux.com/digtux/lander)
-
-Simple little landing homepage..
-
-- Search all the Ingresses in the current context cluster 
-- Show any with the appropriate Annotations 
+- Search all the Ingresses in the current context cluster
+- Show any with the appropriate Annotations
 - simple vuejs UI to query the golang server
 - there is a lightweight cache system to ensure k8s API chatter is limited
 - guess colour scheme based on hostname
-- "identicon" favicons generated against hostname
+- Unique "identicon" favicons generated against hostname (nicer+predictable bookmarks for multiple k8s clusters)
+- Identicons themed with the colours you decide (see: `-hex` when deploying lander)
 
-The available annotations for an Ingress (with `-annotationBase` startup flag of `lander.doddle.com`)
- - `"lander.doddle.com/show": "true"` 
+The available annotations for an Ingress (with `-annotationBase` startup flag of `lander.doddle.tech`)
+ - `"lander.doddle.tech/show": "true"`
  Note string, not bool
- - `"lander.doddle.com/name": "Kibana"` 
+ - `"lander.doddle.tech/name": "Kibana"`
  Service name, defaults to K8s Ingress service name
- - `"lander.doddle.com/description": "A free text description"` Defaults to blank string
- - `"lander.doddle.com/icon": "kibana.png"` 
- A file in the ./assets directory. Defaults to matching a file with a lowercase("lander.doddle.com/name" or service name) and fallsback to `link.png` if none is found
- - `"lander.doddle.com/url": "https://doddle.com"` URL to link to. Defaults to K8s Ingress URL. 
+ - `"lander.doddle.tech/description": "A free text description"` Defaults to blank string
+ - `"lander.doddle.tech/icon": "kibana.png"`
+ A file in the ./assets directory. Defaults to matching a file with a lowercase("lander.doddle.tech/name" or service name) and fallback to `link.png` if none is found
+ - `"lander.doddle.com/url": "https://doddle.com"` URL to link to. Defaults to K8s Ingress URL.
 
 
-## back
+# local development
 
-The golang app supports a few flags..:
-- `-annotationBase` the base of the annotations to use. Appended with `/show` to figure the annotations above
-- `-clusterFQDN` The cluster this lander is operating in. Used for display and identicon purposes only.
-- `-hex` the hex colour to be used for the identicon.. EG: `#26c5e8`, `#123`, `#b2C`
-- `-color` the colorscheme (vuetify) to be handed to the frontend.. See: [material-colors](https://vuetifyjs.com/en/styles/colors/#material-colors)
+To run or develop lander follow the next steps:
 
-If you run this locally on your computer it will auto-detect your `$KUBECONFIG` and use the current context.
+## running the VueJS front-end
 
-For example, my k8s cluster's context is call: `mycluster.example.com`
-
-and in this cluster I have:
-
-- an ingress for prometheus: `mycluster.example.com/prom`
-- an ingress for alertmanager: `mycluster.example.com/alerts`
-
-This means I can run the app with:
-
-```
-go run ."
-```
-
-curl it and see if u get any endpoints detected
-```
-curl localhost:8000/v1/endpoints
-```
-
-
-
-## front
-
-Once the backend is running.. you can now launch the frontend
-
-The frontend listens on `:8080` and will proxy traffic -> `localhost:8000` as you develop
+The frontend listens on `:8080` and will proxy traffic -> `localhost:8000` in development mode.
 
 Simply:
 ```
@@ -67,14 +36,58 @@ npm i --from-lockfile
 npm run serve
 ```
 
+Good.. now that the front-end is running.. launch the backend:
+
+
+## running the backend
+
+The backend listens on `:8000` and will read assets from a relative path of: `./frontend/dist`
+
+The golang app supports a few flags..:
+- `-annotationBase` the base of the annotations to use. Appended with `/show` to figure the annotations above
+- `-clusterFQDN` The cluster this lander is operating in. Used for display and identicon purposes only.
+- `-hex` the hex colour to be used for the identicon.. EG: `#26c5e8`, `#123`, `#b2C`
+- `-color` the colorscheme (vuetify) to be handed to the frontend.. See: [material-colors](https://vuetifyjs.com/en/styles/colors/#material-colors)
+
+If you run this locally on your computer it will auto-detect your `$KUBECONFIG` and use the current context.
+```
+go run .
+```
+
+curl it and see if u get any endpoints detected
+```
+curl localhost:8000/v1/endpoints
+```
+
+NOTE: opening `:8000` in your web browser won't render anything until after you've run `npm run build` in the frontend. For local-development of the UI we recommend using the VueJS steps above.
+
+## Adding a link
+
+You'll need to add an annotation to an ingress to see it in the "Links" section
+
+For example.. In the following example we add:
+1. the annotation `lander.doddle.tech/show="true"`
+2. to an ingress called `prometheus`
+3. in the namespace `monitoring`
+
+```sh
+export NAMESPACE=monitoring
+export INGRESS=prometheus
+kubectl annotate \
+  -n $NAMESPACE \
+  ingress/$INGRESS \
+  lander.doddle.tech/show="true" --overwrite
+```
+
+Landers cache may not make the result show up immediately, but if you restart the golang api or wait a minute you should be able to see a link now
+
 # TODOS:
 
-- throw in some icons for common services such as prometheus+grafana etc and present a very simple list of links (initial purpose of this)
-- Generate an Identicon for the server based on the hostname header
-- search the hostname and set the identicon colour based on some globs.. etc `dev` `staging` `prod` should allow different (but predicible) colours
-- map the identicon so we get a favicon into users browsers
+Nice-to-haves/ideas for the future:
 
-- lightweight react/vue frontend (SPA) would rock.. we can actually extend this to return simple and useful information. EG prometheus metrics, service counts, warnings about ingresses without "alive" services (no k8s endpoints)
-
+- allow adding your own icons
+- more documentation
+- more tests
 - as this will live behind oauth2proxy like many other components, we can determine their username/email.. greet them
 - maybe pull some basic info from RBAC if we're able to determine their github groups (EG `hello <persons name>.. you have X namespaces you can play with on this cluster`)
+- some information about cronjobs (or some CRDs potentially)

--- a/README.md
+++ b/README.md
@@ -1,26 +1,35 @@
-# lander
+# Lander
 
-Simple kubernetes landing page..
+A simple kubernetes (cluster) landing page
 
-- Search all the Ingresses in the current context cluster
-- Show any with the appropriate Annotations
+- search all the Ingresses in the current context cluster
+- show any with the appropriate Annotations
 - simple vuejs UI to query the golang server
 - there is a lightweight cache system to ensure k8s API chatter is limited
-- guess colour scheme based on hostname
-- Unique "identicon" favicons generated against hostname (nicer+predictable bookmarks for multiple k8s clusters)
 - Identicons themed with the colours you decide (see: `-hex` when deploying lander)
-
-The available annotations for an Ingress (with `-annotationBase` startup flag of `lander.doddle.tech`)
- - `"lander.doddle.tech/show": "true"`
- Note string, not bool
- - `"lander.doddle.tech/name": "Kibana"`
- Service name, defaults to K8s Ingress service name
- - `"lander.doddle.tech/description": "A free text description"` Defaults to blank string
- - `"lander.doddle.tech/icon": "kibana.png"`
- A file in the ./assets directory. Defaults to matching a file with a lowercase("lander.doddle.tech/name" or service name) and fallback to `link.png` if none is found
- - `"lander.doddle.com/url": "https://doddle.com"` URL to link to. Defaults to K8s Ingress URL.
+- Unique "identicon" favicons generated against hostname (nicer+predictable bookmarks for multiple k8s clusters)
 
 
+# Runtime flags
+
+```sh
+  -annotationBase string
+    	The base of the annotations used for lander. e.g. lander.doddle.tech for annotations like lander.doddle.tech/show (default "lander.doddle.tech")
+  -clusterFQDN string
+    	The cluster this lander is operating in. Used for display and identicon purposes only. (default "k8s.example.com")
+  -clusters string
+    	comma seperated list of clusters (default "cluster1.example.com,cluster2.example.com")
+  -color string
+    	Main color scheme (See: https://vuetifyjs.com/en/styles/colors/#material-colors) (default "light-blue lighten-2")
+  -debug
+    	debug
+  -hex string
+    	identicon color, hex string, eg #112233, #123, #bAC (default "#26c5e8")
+  -labels string
+    	comma seperated list of node labels you care about (default "kubernetes.io/role,node.kubernetes.io/instance-type,node.kubernetes.io/instancegroup,topology.kubernetes.io/zone")
+```
+
+---
 # local development
 
 To run or develop lander follow the next steps:

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -38,7 +38,7 @@
         </v-col>
 
         <v-col cols="1" style="text-align:right">
-          <v-btn href="https://github.com/digtux/lander" target="_blank" text>
+          <v-btn href="https://github.com/doddle/lander" target="_blank" text>
             <span class="mr-2"></span>
             <v-icon>mdi-open-in-new</v-icon>
           </v-btn>

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/digtux/lander
+module github.com/doddle/lander
 
 go 1.14
 

--- a/handlers.go
+++ b/handlers.go
@@ -5,11 +5,11 @@ import (
 	"os"
 	"strings"
 
-	"github.com/digtux/lander/pkg/deployments"
-	"github.com/digtux/lander/pkg/endpoints"
-	"github.com/digtux/lander/pkg/identicon/identicon"
-	"github.com/digtux/lander/pkg/nodes"
-	"github.com/digtux/lander/pkg/statefulsets"
+	"github.com/doddle/lander/pkg/deployments"
+	"github.com/doddle/lander/pkg/endpoints"
+	"github.com/doddle/lander/pkg/identicon/identicon"
+	"github.com/doddle/lander/pkg/nodes"
+	"github.com/doddle/lander/pkg/statefulsets"
 	"github.com/gofiber/fiber/v2"
 	"k8s.io/client-go/kubernetes"
 )

--- a/main.go
+++ b/main.go
@@ -27,7 +27,6 @@ var (
 		"comma seperated list of node labels you care about",
 	)
 
-	flagAssetPath  = flag.String("assetPath", "./frontend/public/assets", "Path to icon images for services. Relative to main.go")
 	availableIcons []string
 	flagDebug      = flag.Bool("debug", false, "debug")
 	clusterList    []string
@@ -85,6 +84,6 @@ func main() {
 
 	startRoutes(app)
 
-	logger.Info("starting webserver on :8000")
+	logger.Info("starting webserver on http://0.0.0.0:8000")
 	logger.Fatal(app.Listen(":8000"))
 }

--- a/pkg/chart/README.md
+++ b/pkg/chart/README.md
@@ -12,7 +12,7 @@ These types allow constructing json to tweak chart options on the front'ends pie
 package foo
 
 import (
-    "github.com/digtux/lander/pkg/chart"
+    "github.com/doddle/lander/pkg/chart"
 )
 
 

--- a/pkg/chart/chart-types.go
+++ b/pkg/chart/chart-types.go
@@ -6,7 +6,7 @@ package chart
 Example usage:
 
 import (
-	"github.com/digtux/lander/pkg/chart"
+	"github.com/doddle/lander/pkg/chart"
 )
 
 

--- a/pkg/deployments/deployments-types.go
+++ b/pkg/deployments/deployments-types.go
@@ -1,6 +1,6 @@
 package deployments
 
-import "github.com/digtux/lander/pkg/chart"
+import "github.com/doddle/lander/pkg/chart"
 
 type FinalPieChart struct {
 	ChartOpts chart.Opts `json:"chartOptions"`

--- a/pkg/deployments/deployments.go
+++ b/pkg/deployments/deployments.go
@@ -2,7 +2,7 @@ package deployments
 
 import (
 	"context"
-	"github.com/digtux/lander/pkg/chart"
+	"github.com/doddle/lander/pkg/chart"
 	"github.com/patrickmn/go-cache"
 	"github.com/withmandala/go-log"
 	v1 "k8s.io/api/apps/v1"

--- a/pkg/endpoints/endpoints.go
+++ b/pkg/endpoints/endpoints.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/digtux/lander/pkg/util"
+	"github.com/doddle/lander/pkg/util"
 	"github.com/patrickmn/go-cache"
 	"github.com/withmandala/go-log"
 	"k8s.io/api/extensions/v1beta1"
@@ -66,7 +66,7 @@ func ReallyAssemble(
 						Class:       getIngressClass(logger, ingress),
 						Description: serviceDescription,
 						Name:        serviceName,
-						Icon:        serviceIcon,
+						Icon:        "assets/"+serviceIcon,
 					})
 				}
 			}

--- a/pkg/endpoints/endpoints.go
+++ b/pkg/endpoints/endpoints.go
@@ -66,7 +66,7 @@ func ReallyAssemble(
 						Class:       getIngressClass(logger, ingress),
 						Description: serviceDescription,
 						Name:        serviceName,
-						Icon:        "assets/"+serviceIcon,
+						Icon:        serviceIcon,
 					})
 				}
 			}

--- a/pkg/endpoints/endpoints_test.go
+++ b/pkg/endpoints/endpoints_test.go
@@ -3,7 +3,7 @@ package endpoints
 import (
 	"testing"
 
-	"github.com/digtux/lander/pkg/util"
+	"github.com/doddle/lander/pkg/util"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/nodes/nodes-pie-types.go
+++ b/pkg/nodes/nodes-pie-types.go
@@ -1,6 +1,6 @@
 package nodes
 
-import "github.com/digtux/lander/pkg/chart"
+import "github.com/doddle/lander/pkg/chart"
 
 type FinalPieChart struct {
 	ChartOpts chart.Opts `json:"chartOptions"`

--- a/pkg/nodes/nodes.go
+++ b/pkg/nodes/nodes.go
@@ -3,7 +3,7 @@ package nodes
 import (
 	"context"
 	"fmt"
-	"github.com/digtux/lander/pkg/chart"
+	"github.com/doddle/lander/pkg/chart"
 	v1 "k8s.io/api/core/v1"
 	"math"
 	"strings"

--- a/pkg/statefulsets/statefulsets-types.go
+++ b/pkg/statefulsets/statefulsets-types.go
@@ -1,7 +1,7 @@
 package statefulsets
 
 import (
-	"github.com/digtux/lander/pkg/chart"
+	"github.com/doddle/lander/pkg/chart"
 )
 
 type FinalPieChart struct {

--- a/pkg/statefulsets/statefulsets.go
+++ b/pkg/statefulsets/statefulsets.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/digtux/lander/pkg/chart"
+	"github.com/doddle/lander/pkg/chart"
 	"github.com/patrickmn/go-cache"
 	"github.com/withmandala/go-log"
 	v1 "k8s.io/api/apps/v1"

--- a/preflight.go
+++ b/preflight.go
@@ -42,7 +42,7 @@ func onStartup(logger *log.Logger) {
 		clientSet,
 		*flagLanderAnnotationBase,
 	)
-	files, err := ioutil.ReadDir(*flagAssetPath)
+	files, err := ioutil.ReadDir("./frontend/dist/assets")
 	if err != nil {
 		logger.Fatal(err)
 	}

--- a/preflight.go
+++ b/preflight.go
@@ -6,7 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/digtux/lander/pkg/endpoints"
+	"github.com/doddle/lander/pkg/endpoints"
 	"github.com/withmandala/go-log"
 	"k8s.io/client-go/kubernetes"
 )


### PR DESCRIPTION
- removed the `flagAssetPath` flag, we can add a feature to over-ride images later (after the assets are packed into the golang binary)
- hopefully improved the documentation a little