### PR TITLE
Adding k8s versions to the table of nodes (based on kubelet version)

### DIFF
--- a/pkg/nodes/nodes-table-types.go
+++ b/pkg/nodes/nodes-table-types.go
@@ -6,6 +6,7 @@ type NodeStats struct {
 	AgeSeconds  int               `json:"age"`
 	Schedulable bool              `json:"schedulable"`
 	LabelMap    map[string]string `json:"labels"`
+	Version     string            `json:"version"`
 }
 type NodeTable struct {
 	Nodes   []NodeStats    `json:"nodes"`

--- a/pkg/nodes/nodes.go
+++ b/pkg/nodes/nodes.go
@@ -126,11 +126,15 @@ func AssembleTable(
 			matchedLabels[humanKey] = x
 		}
 
+		// We're going to assume the node is this version (of k8s)
+		kubeletVersion := i.Status.NodeInfo.KubeletVersion
+
 		newNode := NodeStats{
 			AgeSeconds:  intergerOnly(age.Seconds()),
 			Ready:       isReady(i),
 			Schedulable: isSchedulable(i),
 			Name:        i.Name,
+			Version:     kubeletVersion,
 			LabelMap:    matchedLabels,
 		}
 		nodeStats = append(nodeStats, newNode)
@@ -145,6 +149,7 @@ func AssembleTable(
 		{Text: "Ready", Value: "ready"},
 		{Text: "Schedulable", Value: "schedulable"},
 		{Text: "Age", Value: "age"},
+		{Text: "Version", Value: "version"},
 	}
 
 	for _, customLabel := range labelSlices {


### PR DESCRIPTION
Show the k8s version

![image](https://user-images.githubusercontent.com/462087/165720962-eab6b80e-137e-478b-bfe9-085397dc2820.png)
