### PR TITLE
show when deployments were last updated

### DIFF
--- a/frontend/src/components/TableDeployments.vue
+++ b/frontend/src/components/TableDeployments.vue
@@ -105,6 +105,7 @@ export default {
       { text: 'progressing', value: 'progressing' },
       { text: 'replicas (desired)', value: 'replicas' },
       { text: 'replicas (available)', value: 'replicas_available' },
+      { text: 'changed', value: 'changed' },
     ],
   }),
 


### PR DESCRIPTION
Its a little rough, but this way people can see how long ago a deployment changed. (Based on when the last replicaset was rolled)

![image](https://user-images.githubusercontent.com/462087/165727914-15a16491-2509-4c39-8906-e265b898012e.png)


Later will maybe update this to a more human-readable "how long since" representation like the node age:

![image](https://user-images.githubusercontent.com/462087/165732833-6a3eb653-1157-4e7e-b72b-c04ef1075d1a.png)
