### PR TITLE
adds a kernel version column to the node table

### DIFF
--- a/pkg/nodes/nodes-table-types.go
+++ b/pkg/nodes/nodes-table-types.go
@@ -7,6 +7,7 @@ type NodeStats struct {
 	Schedulable bool              `json:"schedulable"`
 	LabelMap    map[string]string `json:"labels"`
 	Version     string            `json:"version"`
+	Kernel      string            `json:"kernel"`
 }
 type NodeTable struct {
 	Nodes   []NodeStats    `json:"nodes"`

--- a/pkg/nodes/nodes.go
+++ b/pkg/nodes/nodes.go
@@ -128,6 +128,7 @@ func AssembleTable(
 
 		// We're going to assume the node is this version (of k8s)
 		kubeletVersion := i.Status.NodeInfo.KubeletVersion
+		kernel := i.Status.NodeInfo.KernelVersion
 
 		newNode := NodeStats{
 			AgeSeconds:  intergerOnly(age.Seconds()),
@@ -136,6 +137,7 @@ func AssembleTable(
 			Name:        i.Name,
 			Version:     kubeletVersion,
 			LabelMap:    matchedLabels,
+			Kernel:      kernel,
 		}
 		nodeStats = append(nodeStats, newNode)
 	}
@@ -150,6 +152,7 @@ func AssembleTable(
 		{Text: "Schedulable", Value: "schedulable"},
 		{Text: "Age", Value: "age"},
 		{Text: "Version", Value: "version"},
+		{Text: "Kernel", Value: "kernel"},
 	}
 
 	for _, customLabel := range labelSlices {


### PR DESCRIPTION
handy when updating instance groups to spot older nodes

![image](https://user-images.githubusercontent.com/462087/173079475-f73240ec-054b-4547-b861-8936397f0c60.png)
